### PR TITLE
add manually runnable retroactive labeling

### DIFF
--- a/.github/workflows/manage-issue-labels.yml
+++ b/.github/workflows/manage-issue-labels.yml
@@ -2,6 +2,12 @@
 name: Issue Labels
 
 on:
+  workflow_dispatch:
+    inputs:
+      issue_body:
+        description: "The issue body"
+        required: false
+        type: string
   issues:
     types: [opened, labeled, unlabeled]
 
@@ -18,10 +24,12 @@ jobs:
         template: [ 000-bug-report.yml, 001-feature-request.yml ]
     steps:
       - uses: actions/checkout@v4
+
       - name: Parse issue form
         uses: stefanbuck/github-issue-parser@v3
         id: issue-parser
         with:
+          issue-body: ${{ github.event.issue?.body ?? inputs.issue_body }}
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on mc-version field

--- a/.github/workflows/manual-autolabel.yml
+++ b/.github/workflows/manual-autolabel.yml
@@ -1,0 +1,42 @@
+# Manages labels on new issues
+name: Retroactively apply Issue Labels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  label-all:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # IDK if this is needed to run manage-issue-labels, but it doesn't hurt so
+      actions: write
+    steps:
+      - name: Labelifier
+        uses: actions/github-script@v7
+        id: label-em
+        with:
+          script: |
+            github.paginate(github.rest.issues.listForRepo, {
+              owner: "GregTechCEu",
+              repo: "GregTech-Modern",
+            }).then((issues) => {
+              // issues is an array of all issue objects
+              issues.forEach((issue) => {
+                if (issue.pull_request != undefined) {
+                    // if it's a pull request, skip it.
+                    return;
+                }
+                octokit.rest.actions.createWorkflowDispatch({
+                  owner: "GregTechCEu",
+                  repo: "GregTech-Modern",
+                  workflow_id: "manage-issue-labels",
+                  ref: ${{ github.ref }},
+                  inputs: {
+                    issue_number: issue.body
+                  }
+                });
+              });
+            });


### PR DESCRIPTION
## What
I pushed this to the wrong branch 💀 

## Implementation Details
retroactively apply labels to all issues (this only needs to run once loll)

## Outcome
all issues are labeled 👍 